### PR TITLE
Fixed bug of duplicating object reference on creation in "Lesson17(OOP)/cart.js"

### DIFF
--- a/Lesson17(OOP)/cart.js
+++ b/Lesson17(OOP)/cart.js
@@ -1,11 +1,11 @@
-function Cart()
+function Cart(localStorageKey)
 {
     const cart = {
         cartItems: undefined,
 
         loadCartFromStorage()
         {
-            this.cartItems = JSON.parse(localStorage.getItem('cart-oop')) || [
+            this.cartItems = JSON.parse(localStorage.getItem(localStorageKey)) || [
                 {
                     productId: 'e43638ce-6aa0-4b85-b27f-e1d07eb678c6',
                     quantity: 2,
@@ -21,7 +21,7 @@ function Cart()
 
         saveLocal()
         {
-            localStorage.setItem('cart-oop', JSON.stringify(this.cartItems));
+            localStorage.setItem(localStorageKey, JSON.stringify(this.cartItems));
         },
 
         addToCart(productId, quantity = 1)
@@ -97,11 +97,13 @@ function Cart()
     return cart;
 }
 
-const cart = Cart();
+// Added arguments for passing correct localStorageKey
+
+const cart = Cart('cart-oop');
 
 cart.loadCartFromStorage();
 
-const businessCart = Cart();
+const businessCart = Cart('cart-business');
 
 businessCart.loadCartFromStorage();
 


### PR DESCRIPTION
Fixed the bug by adding parameters that will decide the localStorageKey for creation of new object to ensure different localStorage object references.